### PR TITLE
Add composer/installers to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 		}
 	],
 	"require": {
+		"composer/installers": "~1.0",
 		"bugsnag/bugsnag": "2.*"
 	}
 }


### PR DESCRIPTION
This is needed to properly install as a CakePHP plugin: see https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
