### PR TITLE
Remove Exception typehint for php 7 compatibility

### DIFF
--- a/Lib/BugsnagErrorHandler.php
+++ b/Lib/BugsnagErrorHandler.php
@@ -55,7 +55,7 @@ class BugsnagErrorHandler extends ErrorHandler
         return parent::handleError($code, $description, $file, $line, $context);
     }
 
-    public static function handleException(Exception $exception)
+    public static function handleException($exception)
     {
         static::getBugsnag()->exceptionHandler($exception);
         return parent::handleException($exception);


### PR DESCRIPTION
Per the [Cakephp library](https://github.com/cakephp/cakephp/commit/2fdd3030e22794d638313a83cf4222ed14407779), the typehint in the exception handler has been removed for PHP7 compatibility. Leaving it in breaks this handler as the signatures are incompatible.
